### PR TITLE
Fix binder launch

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+# Requirements file for binder
+jupyterlab>=4.0.0 


### PR DESCRIPTION
Add `requirements.txt` file for binder that sets up `jupyterlab>=4`. @jtpio This fixes the broken binder launch on `main` branch as it is using `jupyterlab 3.x`