### PR TITLE
Fix `jupyterlab_theme_toggler` in `python-package` config

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
       "python-packages": [
         "packages/logout-extension:jupyterlab_logout",
         "packages/topbar-text-extension:jupyterlab_topbar_text",
-        "packages/theme-toggler-extension:jupyterlab_theme-toggler"
+        "packages/theme-toggler-extension:jupyterlab_theme_toggler"
       ],
       "npm-install-options": "--legacy-peer-deps",
       "pydist-extra-check-cmds": [


### PR DESCRIPTION
So it's consistent with the name of the package.