### PR TITLE
Revert "Move populate-release step to prep-release workflow"

### DIFF
--- a/.github/workflows/prep-release.yml
+++ b/.github/workflows/prep-release.yml
@@ -37,15 +37,6 @@ jobs:
           since: ${{ github.event.inputs.since }}
           since_last_stable: ${{ github.event.inputs.since_last_stable }}
 
-      - name: Populate Release
-        id: populate-release
-        uses: jupyter-server/jupyter_releaser/.github/actions/populate-release@v2
-        with:
-          token: ${{ secrets.ADMIN_GITHUB_TOKEN }}
-          branch: ${{ github.event.inputs.branch }}
-          release_url: ${{ steps.prep-release.outputs.release_url }}
-          steps_to_skip: ${{ github.event.inputs.steps_to_skip }}
-
       - name: "** Next Step **"
         run: |
-          echo "Optional): Review Draft Release: ${{ steps.populate-release.outputs.release_url }}" 
+          echo "Optional): Review Draft Release: ${{ steps.prep-release.outputs.release_url }}" 

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -22,6 +22,15 @@ jobs:
     steps:
       - uses: jupyterlab/maintainer-tools/.github/actions/base-setup@v1
 
+      - name: Populate Release
+        id: populate-release
+        uses: jupyter-server/jupyter_releaser/.github/actions/populate-release@v2
+        with:
+          token: ${{ secrets.ADMIN_GITHUB_TOKEN }}
+          branch: ${{ github.event.inputs.branch }}
+          release_url: ${{ github.event.inputs.release_url }}
+          steps_to_skip: ${{ github.event.inputs.steps_to_skip }}
+
       - name: Finalize Release
         id: finalize-release
         env:
@@ -33,7 +42,7 @@ jobs:
         uses: jupyter-server/jupyter-releaser/.github/actions/finalize-release@v2
         with:
           token: ${{ secrets.ADMIN_GITHUB_TOKEN }}
-          release_url: ${{ github.event.inputs.release_url }}
+          release_url: ${{ steps.populate-release.outputs.release_url }}
 
       - name: "** Next Step **"
         if: ${{ success() }}


### PR DESCRIPTION
Reverts jupyterlab-contrib/jupyterlab-topbar#108

Based on the observation from https://github.com/jupyter-server/jupyter_releaser/issues/552#issuecomment-1960941818, with the release commit being created during the `populate-release` step.

A better approach for checking the assets would be to inspect the latest run of the `check_release` workflow.